### PR TITLE
resolve review comments

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/common/thehive/schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/thehive/schema.ts
@@ -55,7 +55,7 @@ export const ExecutorSubActionCreateAlertParamsSchema = schema.object({
   source: schema.string(),
   sourceRef: schema.string(),
   severity: schema.nullable(schema.number({ defaultValue: TheHiveSeverity.MEDIUM })),
-  isRuleSeverity: schema.boolean(),
+  isRuleSeverity: schema.nullable(schema.boolean({ defaultValue: false })),
   tlp: schema.nullable(schema.number({ defaultValue: TheHiveTLP.AMBER })),
   tags: schema.nullable(schema.arrayOf(schema.string())),
   body: schema.nullable(schema.string()),

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.test.tsx
@@ -61,6 +61,7 @@ describe('TheHiveParamsFields renders', () => {
     expect(getByTestId('descriptionTextArea')).toBeInTheDocument();
     expect(getByTestId('tagsInput')).toBeInTheDocument();
     expect(getByTestId('severitySelectInput')).toBeInTheDocument();
+    expect(getByTestId('rule-severity-toggle')).toBeInTheDocument();
     expect(getByTestId('tlpSelectInput')).toBeInTheDocument();
     expect(getByTestId('typeInput')).toBeInTheDocument();
     expect(getByTestId('sourceInput')).toBeInTheDocument();
@@ -68,5 +69,6 @@ describe('TheHiveParamsFields renders', () => {
 
     expect(getByTestId('severitySelectInput')).toHaveValue('2');
     expect(getByTestId('tlpSelectInput')).toHaveValue('2');
+    expect(getByTestId('rule-severity-toggle')).not.toBeChecked();
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.tsx
@@ -155,11 +155,11 @@ export const TheHiveParamsAlertFields: React.FC<ActionParamsProps<ExecutorParams
         }}
         errors={errors['createAlertParam.sourceRef'] as string[]}
       />
-      {!isTest && isRuleSeverity && (
+      {!isTest && (
         <EuiFormRow fullWidth>
           <EuiSwitch
             label={translations.IS_RULE_SEVERITY_LABEL}
-            checked={isRuleSeverity}
+            checked={Boolean(isRuleSeverity)}
             compressed={true}
             data-test-subj="rule-severity-toggle"
             onChange={(e) => {
@@ -176,7 +176,7 @@ export const TheHiveParamsAlertFields: React.FC<ActionParamsProps<ExecutorParams
           />
         </EuiFormRow>
       )}
-      {!isRuleSeverity && (
+      {!Boolean(isRuleSeverity) && (
         <EuiFormRow fullWidth label={translations.SEVERITY_LABEL}>
           <EuiSelect
             fullWidth

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/thehive/params_alert.tsx
@@ -44,7 +44,7 @@ export const TheHiveParamsAlertFields: React.FC<ActionParamsProps<ExecutorParams
   const [selectedOptions, setSelected] = useState<Array<{ label: string }>>(
     alert.tags?.map((tag) => ({ label: tag })) ?? []
   );
-  const [isRuleSeverity, setIsRuleSeverity] = useState<boolean>(alert.isRuleSeverity);
+  const [isRuleSeverity, setIsRuleSeverity] = useState<boolean>(Boolean(alert.isRuleSeverity));
 
   const onCreateOption = (searchValue: string) => {
     setSelected([...selectedOptions, { label: searchValue }]);

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/thehive/render.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/thehive/render.test.ts
@@ -19,7 +19,7 @@ const params = {
     source: 'source',
     sourceRef: '{{alert.uuid}}',
     tlp: 2,
-    severity: 3,
+    severity: 1,
     isRuleSeverity: true,
     body: '{"observables":[{"datatype":"url","data":"{{url}}"}],"tags":["test"]}',
   },
@@ -45,6 +45,26 @@ describe('TheHive - renderParameterTemplates', () => {
       tlp: 2,
       severity: 3,
       isRuleSeverity: true,
+      body: `{"observables":[{"datatype":"url","data":"${variables.url}"}],"tags":["test"]}`,
+    });
+  });
+
+  it('should not use rule severity if isRuleSeverity is false', () => {
+    const paramswithoutRuleSeverity = {
+      ...params,
+      subActionParams: { ...params.subActionParams, isRuleSeverity: false },
+    };
+    const result = renderParameterTemplates(logger, paramswithoutRuleSeverity, variables);
+
+    expect(result.subActionParams).toEqual({
+      title: 'title',
+      description: 'description',
+      type: 'type',
+      source: 'source',
+      sourceRef: variables.alert.uuid,
+      tlp: 2,
+      severity: 1,
+      isRuleSeverity: false,
       body: `{"observables":[{"datatype":"url","data":"${variables.url}"}],"tags":["test"]}`,
     });
   });


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



